### PR TITLE
Improved trajectory CSV export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,11 +386,13 @@ The following APIs are used to initialise the necessary instances and trigger th
 3) /csv_export/trajectory (GET)
 
     Parameters:
-    - subject: IRI of subject
-    - rdf_type: RDF type of calculation
-    - exposure_table: table name of exposure dataset
-    - lowerbound (optional): lowerbound of trajectory time series
-    - upperbound (optional): upperbound of trajectory time series
+    - `subject`: IRI of subject
+    - `rdf_type`: RDF type of calculation
+    - `exposure_table`: table name of exposure dataset
+    - `lowerbound` (optional): lowerbound of trajectory time series
+    - `upperbound` (optional): upperbound of trajectory time series
+    - `include_lat_lng` (optional, default true): include geolocation in exported CSV file
+    - `refresh_of_cache` (optional, default false): refresh outgoing federation cache before querying
 
     Example usage:
 

--- a/agent/interactor/csv_export.py
+++ b/agent/interactor/csv_export.py
@@ -97,17 +97,16 @@ def trajectory():
     if trip_iri is not None:
         data_iri_list_to_query.append(trip_iri)
 
-    # dictionary hierarchy [dataset_year][calculation][distance] = result_iri
+    # dictionary hierarchy [exposure_table][calculation][distance] = result_iri
     overall_result = defaultdict(lambda: defaultdict(dict))
     for exposure_table in exposure_table_list:
         exposure_dataset_iri = get_dataset_iri(table_name=exposure_table)
-        dataset_year = _get_dataset_year(exposure_dataset_iri)
         for calculation in rdf_type_list:
             logger.info(
                 f"""Querying results for calculation: <{calculation}>, dataset: {exposure_table}""")
             distance_to_result_dict = _get_distance_to_result_dict(
                 subject=subject, exposure=exposure_dataset_iri, calculation_type=calculation)
-            overall_result[dataset_year][calculation] = distance_to_result_dict
+            overall_result[exposure_table][calculation] = distance_to_result_dict
             data_iri_list_to_query.extend(distance_to_result_dict.values())
 
     logger.info('Querying time series')
@@ -131,14 +130,14 @@ def trajectory():
         data_to_write.append(time_series.get_value_list(trip_iri))
         headers.append('trip index')
 
-    for year in overall_result.keys():
-        for calculation in overall_result[year].keys():
-            for distance in overall_result[year][calculation].keys():
-                result_iri = overall_result[year][calculation][distance]
+    for exposure_table in overall_result.keys():
+        for calculation in overall_result[exposure_table].keys():
+            for distance in overall_result[exposure_table][calculation].keys():
+                result_iri = overall_result[exposure_table][calculation][distance]
                 result_list = time_series.get_value_list(result_iri)
                 data_to_write.append(result_list)
                 headers.append(
-                    str(year) + '_' + re.findall(r'[^/]+$', calculation)[0] + '_' + str(distance))
+                    exposure_table + '_' + re.findall(r'[^/]+$', calculation)[0] + '_' + str(distance))
 
     rows = zip(*data_to_write)
 

--- a/agent/interactor/csv_export.py
+++ b/agent/interactor/csv_export.py
@@ -16,6 +16,7 @@ import sys
 from datetime import datetime
 
 from agent.utils.ts_client import TimeSeriesClient
+from agent.utils.stack_gateway import stack_clients_view
 
 logger = agentlogging.get_logger('dev')
 
@@ -93,6 +94,16 @@ def trajectory():
     upperbound = request.args.get('upperbound')
     lowerbound = request.args.get('lowerbound')
 
+    include_lat_lng = request.args.get('include_lat_lng', 'true')
+    refresh_of_cache = request.args.get('refresh_of_cache', 'false')
+
+    # If requested, refresh the cache of the outgoing federation
+    # before querying it.
+    if refresh_of_cache.lower() == 'true':
+        of_rep_id = stack_clients_view.Rdf4jService.OUT_STACK_REPO_ID
+        logger.info(f"Refreshing outgoing federation ('{of_rep_id}') cache...")
+        stack_clients_view.Rdf4jClient.getInstance().refreshRepositoryCache(of_rep_id)
+
     data_iri_list_to_query = [subject]
     if trip_iri is not None:
         data_iri_list_to_query.append(trip_iri)
@@ -114,17 +125,18 @@ def trajectory():
         data_iri_list_to_query, lowerbound, upperbound)
     points = [wkt.loads(s) for s in time_series.get_value_list(subject)]
 
-    lat_list = []
-    lng_list = []
-
-    for point in points:
-        lat_list.append(point.y)
-        lng_list.append(point.x)
-
     time_list = time_series.get_timestamp_java(subject)
+    data_to_write = [time_list]
+    headers = ['time']
 
-    data_to_write = [time_list, lat_list, lng_list]
-    headers = ['time', 'lat', 'lng']
+    if include_lat_lng.lower() == 'true':
+        lat_list = []
+        lng_list = []
+        for point in points:
+            lat_list.append(point.y)
+            lng_list.append(point.x)
+        data_to_write.extend([lat_list, lng_list])
+        headers.extend(['lat', 'lng'])
 
     if trip_iri is not None:
         data_to_write.append(time_series.get_value_list(trip_iri))

--- a/agent/interactor/csv_export.py
+++ b/agent/interactor/csv_export.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 import json
 from tqdm import tqdm
 import sys
+from datetime import datetime
 
 from agent.utils.ts_client import TimeSeriesClient
 
@@ -395,8 +396,12 @@ def _get_dataset_year(dataset_iri):
     """
 
     query_results = kg_client.remote_store_client.executeQuery(query)
-
-    return query_results.getJSONObject(0).getString('year')
+    try:
+        year = query_results.getJSONObject(0).getString('year')
+    except:
+        year = str(datetime.now().year)
+        logger.info(f"Dataset does not have a start date! Using '{year}' as year.")
+    return year
 
 
 def _chunk_list(values, chunk_size=1000):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   exposure-calculation-agent:
-    image: ghcr.io/theworldavatar/exposure-calculation-agent:2.0.2
+    image: ghcr.io/theworldavatar/exposure-calculation-agent:2.0.3
     build:
       context: .
       target: production


### PR DESCRIPTION
- New optional parameter to refresh outgoing federation cache before querying
- New optional parameter to include/exclude geolocation in the exported CSV (needed for anonymisation)
- Export is now able to handle multiple exposure tables (even if they don't have a year, or have the same year)